### PR TITLE
feat: 유니크 제약 조건으로 같은 날짜의 통계 데이터가 중복으로 쌓이는 것을 DB 레벨에서 방지

### DIFF
--- a/src/main/java/io/eventdriven/batchkafka/domain/entity/CampaignStats.java
+++ b/src/main/java/io/eventdriven/batchkafka/domain/entity/CampaignStats.java
@@ -8,7 +8,15 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 
 @Entity
-@Table(name = "campaign_stats")
+@Table(
+    name = "campaign_stats",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_campaign_stats_date",
+            columnNames = {"campaign_id", "stats_date"}
+        )
+    }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CampaignStats {


### PR DESCRIPTION
 @Table(name = "campaign_stats")
 @Table(
     name = "campaign_stats",
     uniqueConstraints = {
         @UniqueConstraint(
             name = "uk_campaign_stats_date",
             columnNames = {"campaign_id", "stats_date"}
         )
     }
 )

@Table 어노테이션에 유니크 제약조건을 추가하여 campaign_id와 stats_date 두 컬럼의 조합이 유일해야 한다는 제약을 걸었습니다.

배치가 재실행되더라도 같은 날짜의 통계 데이터가 중복으로 쌓이는 것을 DB에서 방지할 수 있습니다.