### PR TITLE
feat: kafka 설정을 통한 메시지 보낼 준비

### DIFF
--- a/src/main/java/io/eventdriven/batchkafka/config/KafkaConfig.java
+++ b/src/main/java/io/eventdriven/batchkafka/config/KafkaConfig.java
@@ -1,0 +1,56 @@
+package io.eventdriven.batchkafka.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    public static final String TOPIC_NAME = "campaign-participation-topic";
+
+    /**
+     * Kafka Producer 설정
+     * - Key: String (Campaign ID 등)
+     * - Value: String (JSON 문자열)
+     */
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    /**
+     * 토픽 자동 생성 설정
+     * - partitions: 3 (병렬 처리를 위해 파티션 3개 설정)
+     * - replicas: 1 (로컬 개발 환경이므로 1개, 운영 환경에서는 3개 권장)
+     */
+    @Bean
+    public NewTopic campaignParticipationTopic() {
+        return TopicBuilder.name(TOPIC_NAME)
+                .partitions(3)
+                .replicas(1)
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,6 @@ spring:
 
   profiles:
     active: local
+
+  kafka:
+    bootstrap-servers: localhost:9092


### PR DESCRIPTION
Kafka와의 통신을 위한 Producer 설정 및 토픽 초기화를 구성했습니다.

- Kafka 브로커 주소 및 메시지 직렬화 방식(String Key / String Value)을 정의한 ProducerFactory를 설정

- 애플리케이션 코드에서 간단히 메시지를 발행할 수 있도록 KafkaTemplate Bean 등록

- 애플리케이션 시작 시 캠페인 참여 이벤트용 토픽이 없으면 자동 생성하도록 설정

- 파티션 수를 3으로 지정하여, 향후 Consumer 확장 시 병렬 처리 기반 마련

-> Kafka 메시지 발행을 안정적이고 확장 가능하게 사용하기 위한 기본 설정입니다.